### PR TITLE
Responsive Navbar

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -26,25 +26,31 @@
     </div>
   </div>
 
-  <nav class="navbar bg-body-tertiary fw-bold row-fluid header">
+  <nav class="navbar navbar-expand-sm bg-body-tertiary fw-bold row header mx-1">
     <div class="container-fluid">
-      <a class="col-4" href="index.html">
+      <a class="col-md-4 d-none d-md-block" href="index.html">
         <img class="img-logo" src="../assets/images/logo.png" alt="Logo" />
       </a>
-      <div class="col-4 d-flex justify-content-center">
+      <div class="col-md-4 d-flex justify-content-start justify-content-md-center">
         <div class="navbar-brand">
           ETERNITY
         </div>
       </div>
-      <div class="col-4 d-flex justify-content-end header" id="navbar-setting">
-        <div class="change-precision-container dropdown header">
-          <button class="btn header" id="change-precision" type="button">Precision: <span
-              id="change-precision-value"></span> <i class="bi bi-gear"></i></button>
-          <ul class="dropdown-menu header">
-            <li><input class="dropdown-item" type="text" id="precision-input" placeholder="Enter the value"></li>
-          </ul>
-        </div>
-        <button class="btn header" id="change-theme">Theme <i id="theme-icon" class="bi bi-sun"></i></button>
+
+      <button class="navbar-toggler header" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-setting">
+        <span class="btn dropdown-toggle header">Settings</span>
+      </button>
+      <div class="col-4 collapse navbar-collapse justify-content-end header" id="navbar-setting">
+        <ul class="change-precision-container dropdown header navbar-nav">
+          <li class="nav-item">
+            <button class="btn header" id="change-precision" type="button">Precision: <span
+                id="change-precision-value"></span> <i class="bi bi-gear"></i>
+            </button>
+          </li>
+          <li class="nav-item">
+            <button class="btn header" id="change-theme">Theme <i id="theme-icon" class="bi bi-sun"></i></button>
+          </li>
+        </ul>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
The navbar is now responsive.
- When shrinking beyond small breakpoint the `Precision` and `Theme` are dropdown items.
- The logo is hidden beyond small breakpoint.

Thank you.

<img width="477" alt="Screenshot 2023-04-09 at 8 19 26 PM" src="https://user-images.githubusercontent.com/99159017/230803806-75e2e2d7-f7f3-4310-abd6-3072781f2f38.png">
<img width="473" alt="Screenshot 2023-04-09 at 8 19 38 PM" src="https://user-images.githubusercontent.com/99159017/230803807-103233d5-6726-4fba-be0a-552d76356758.png">
<img width="463" alt="Screenshot 2023-04-09 at 8 19 47 PM" src="https://user-images.githubusercontent.com/99159017/230803809-2943c6c7-c6ca-4828-89ab-2d42b774757b.png">
<img width="472" alt="Screenshot 2023-04-09 at 8 20 02 PM" src="https://user-images.githubusercontent.com/99159017/230803811-1570377d-f456-48c5-bb48-a4191b7649fe.png">
